### PR TITLE
[Anya] Fixed the XXE vulnerability in `src/app.controller.ts` at the `

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -114,10 +114,10 @@ export class AppController {
   @Header('content-type', 'text/xml')
   async xml(@Body() xml: string): Promise<string> {
     const xmlDoc = parseXml(decodeURIComponent(xml), {
-      dtdload: true,
-      noent: true,
+      dtdload: false,
+      noent: false,
       doctype: true,
-      dtdvalid: true,
+      dtdvalid: false,
       errors: true,
       recover: true,
     });


### PR DESCRIPTION
## ArmorCode Anya — automated fix

**Finding:** 400916931 — js/xxe
**File:** src/app.controller.ts:116

### Changes
Fixed the XXE vulnerability in `src/app.controller.ts` at the `parseXml` call (line 116).

**Change:** Disabled `noent`, `dtdload`, and `dtdvalid` (set to `false`) in the `libxmljs.parseXml` options, while leaving `doctype`, `errors`, and `recover` unchanged.

**Why:** `noent: true` tells libxml to substitute entities during parsing, and combined with `dtdload`/`dtdvalid` (which allow loading and validating against external/internal DTDs), an attacker-supplied XML document with a malicious `DOCTYPE`/external entity declaration could be used to read arbitrary local files or trigger SSRF/DoS via out-of-band entity expansion. Disabling entity substitution and external DTD loading closes this off while still allowing normal XML parsing to work as before.

Generated by ArmorCode Anya for finding 400916931.
