### PR TITLE
[Anya] I fixed the path-injection finding in `src/file/file.controller

### DIFF
--- a/src/file/file.controller.ts
+++ b/src/file/file.controller.ts
@@ -293,9 +293,16 @@ export class FileController {
     @Body() raw: string,
   ): Promise<string> {
     try {
+      const root = path.resolve(process.cwd());
+      const resolvedPath = path.resolve(root, file);
+
+      if (resolvedPath !== root && !resolvedPath.startsWith(root + path.sep)) {
+        throw new BadRequestException(`Invalid paramater 'path' ${file}`);
+      }
+
       if (typeof raw === 'string' || Buffer.isBuffer(raw)) {
-        await fs.promises.access(path.dirname(file), W_OK);
-        await fs.promises.writeFile(file, raw);
+        await fs.promises.access(path.dirname(resolvedPath), W_OK);
+        await fs.promises.writeFile(resolvedPath, raw);
         return `File uploaded successfully at ${file}`;
       }
     } catch (err) {


### PR DESCRIPTION
## ArmorCode Anya — automated fix

**Finding:** 400916924 — js/path-injection
**File:** src/file/file.controller.ts:298

### Changes
I fixed the path-injection finding in `src/file/file.controller.ts` (`uploadFile`, the `@Put('raw')` handler).

**Problem:** The `path` query parameter was passed directly to `fs.promises.access`/`fs.promises.writeFile` without any validation, so a value like `../../etc/cron.d/evil` could let a caller write files anywhere on the filesystem the process has access to.

**Fix:** Before touching the filesystem, the user-supplied `file` path is resolved against the server's working directory (`path.resolve(root, file)`), and the resolved path is checked to ensure it still lives inside that root directory (`resolvedPath === root || resolvedPath.startsWith(root + path.sep)`). If the check fails, a `BadRequestException` is thrown, mirroring the existing `loadCPFile` pattern already used elsewhere in this controller. The write and the `W_OK` access check now operate on the validated `resolvedPath` instead of the raw input, closing the traversal vector while preserving existing behavior for legitimate relative paths.

Generated by ArmorCode Anya for finding 400916924.
